### PR TITLE
Switch on the type of git reference and set its target accordingly

### DIFF
--- a/LibGit2Sharp.Tests/FilterFixture.cs
+++ b/LibGit2Sharp.Tests/FilterFixture.cs
@@ -300,14 +300,14 @@ namespace LibGit2Sharp.Tests
                 this.initCallback = initCallback;
             }
 
-            protected override int Clean(string path, Stream input, Stream output)
+            protected override int Clean(string path, string workingDirectory, Stream input, Stream output)
             {
-                return cleanCallback != null ? cleanCallback(input, output) : base.Clean(path, input, output);
+                return cleanCallback != null ? cleanCallback(input, output) : base.Clean(path, workingDirectory, input, output);
             }
 
-            protected override int Smudge(string path, Stream input, Stream output)
+            protected override int Smudge(string path, string workingDirectory, Stream input, Stream output)
             {
-                return smudgeCallback != null ? smudgeCallback(input, output) : base.Smudge(path, input, output);
+                return smudgeCallback != null ? smudgeCallback(input, output) : base.Smudge(path, workingDirectory, input, output);
             }
 
             protected override int Initialize()

--- a/LibGit2Sharp.Tests/TestHelpers/SubstitutionCipherFilter.cs
+++ b/LibGit2Sharp.Tests/TestHelpers/SubstitutionCipherFilter.cs
@@ -13,13 +13,13 @@ namespace LibGit2Sharp.Tests.TestHelpers
         {
         }
 
-        protected override int Clean(string path, Stream input, Stream output)
+        protected override int Clean(string path, string workingDirectory, Stream input, Stream output)
         {
             CleanCalledCount++;
             return RotateByThirteenPlaces(input, output);
         }
 
-        protected override int Smudge(string path, Stream input, Stream output)
+        protected override int Smudge(string path, string repositoryWorkingDirectory, Stream input, Stream output)
         {
             SmudgeCalledCount++;
             return RotateByThirteenPlaces(input, output);

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -253,17 +253,17 @@ namespace LibGit2Sharp
             {
                 GitReferenceType type = Proxy.git_reference_type(referencePtr);
 
-                DirectReference directRef = targetRef.ResolveToDirectReference();
 
                 if (type == GitReferenceType.Symbolic)
                 {
-                    using (ReferenceSafeHandle handle = Proxy.git_reference_symbolic_set_target(referencePtr, directRef.TargetIdentifier, signature, logMessage))
+                    using (ReferenceSafeHandle handle = Proxy.git_reference_symbolic_set_target(referencePtr, targetRef.CanonicalName, signature, logMessage))
                     {
                         return Reference.BuildFromPtr<Reference>(handle, repo);
                     }
                 }
                 else
                 {
+                    DirectReference directRef = targetRef.ResolveToDirectReference();
                     using (ReferenceSafeHandle handle = Proxy.git_reference_set_target(referencePtr, directRef.Target.Id, signature, logMessage))
                     {
                         return Reference.BuildFromPtr<Reference>(handle, repo);

--- a/LibGit2Sharp/ReferenceCollection.cs
+++ b/LibGit2Sharp/ReferenceCollection.cs
@@ -250,9 +250,25 @@ namespace LibGit2Sharp
             }
 
             using (ReferenceSafeHandle referencePtr = RetrieveReferencePtr(symbolicRef.CanonicalName))
-            using (ReferenceSafeHandle handle = Proxy.git_reference_symbolic_set_target(referencePtr, targetRef.CanonicalName, signature, logMessage))
             {
-                return Reference.BuildFromPtr<Reference>(handle, repo);
+                GitReferenceType type = Proxy.git_reference_type(referencePtr);
+
+                DirectReference directRef = targetRef.ResolveToDirectReference();
+
+                if (type == GitReferenceType.Symbolic)
+                {
+                    using (ReferenceSafeHandle handle = Proxy.git_reference_symbolic_set_target(referencePtr, directRef.TargetIdentifier, signature, logMessage))
+                    {
+                        return Reference.BuildFromPtr<Reference>(handle, repo);
+                    }
+                }
+                else
+                {
+                    using (ReferenceSafeHandle handle = Proxy.git_reference_set_target(referencePtr, directRef.Target.Id, signature, logMessage))
+                    {
+                        return Reference.BuildFromPtr<Reference>(handle, repo);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Since `RetrieveReferencePtr` can return a direct reference for branch names, we have to switch on the references type and update the target with the right method.
