### PR TITLE
tracking branches might point to URLs, not remotes

### DIFF
--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -177,6 +177,16 @@ namespace LibGit2Sharp
                     return null;
                 }
 
+                // upstream git uses the "/" character to denote
+                // when a nick should not be resolved to a remote
+                // TODO:
+                // there's probably some pushspec stuff still to
+                // address here, but let me make this bugfix first
+                if (remoteName.Contains("/"))
+                {
+                    return null;
+                }
+
                 return repo.Network.Remotes[remoteName];
             }
         }

--- a/LibGit2Sharp/Branch.cs
+++ b/LibGit2Sharp/Branch.cs
@@ -236,7 +236,17 @@ namespace LibGit2Sharp
                 return null;
             }
 
-            string trackedReferenceName = Proxy.git_branch_upstream_name(repo.Handle, CanonicalName);
+            string trackedReferenceName = null;
+            try
+            {
+                trackedReferenceName = Proxy.git_branch_upstream_name(repo.Handle, CanonicalName);
+            }
+            catch (InvalidSpecificationException)
+            {
+                // we have no way to pro-actively check this
+                // based on the information available
+                // so we just need to handle this here
+            }
 
             if (trackedReferenceName == null)
             {


### PR DESCRIPTION
Repro:
- create a new repository and make some commits
- create a empty repo on GitHub
- push the changes from the command line: `git push https://github.com/{user}/{repo}.git master --set-upstream`
- drop the repository onto the app

There's some upstream rules that Git uses to determine when something is a "nick" when resolving a remote. These rules aren't around in `libgit2` in this scenario because the user has set the remote to be the full URL, so we get some `InvalidSpecificationException` when trying to lookup the tracking branch.

As a first step, this is how we can correctly handle the checks when looking up tracking branches  - ideally this should live in libgit2 so everyone gets the benefits, but the contract for `git_reference_lookup` indicates it will happily throw `GIT_EINVALIDSPEC` so I need to talk with the team about this in more detail...
